### PR TITLE
Change `getNoaaIndex` parameter order to (latitude, longitude)

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,13 +32,13 @@ class AuroraBorealis extends utils.Adapter {
 	}
 
 	/**
-	 * Calculates the NOAA grid index for the given longitude and latitude.
+	 * Calculates the NOAA grid index for the given latitude and longitude.
 	 *
-	 * @param {number} longitude - the longitude in degrees, negative for west and positive for east
 	 * @param {number} latitude - the latitude in degrees, negative for south and positive for north
+	 * @param {number} longitude - the longitude in degrees, negative for west and positive for east
 	 * @returns {number} The NOAA grid index for the given coordinates
 	 */
-	getNoaaIndex(longitude, latitude) {
+	getNoaaIndex(latitude, longitude) {
 		let rLat = Math.round(latitude);
 		let rLon = Math.round(longitude);
 		if (rLon < 0) {
@@ -163,7 +163,7 @@ class AuroraBorealis extends utils.Adapter {
 				this.terminate(1);
 			}
 
-			const ovationIndex = this.getNoaaIndex(lon, lat);
+			const ovationIndex = this.getNoaaIndex(lat, lon);
 			this.log.debug(`Lon: ${lon}, Lat: ${lat}`);
 			this.log.debug(`Index: ${ovationIndex}`);
 

--- a/main.test.js
+++ b/main.test.js
@@ -35,30 +35,30 @@ Module._load = originalLoad;
 describe("main.js helper methods", () => {
 	it("calculates NOAA index for positive longitude", () => {
 		const adapter = createAdapter({});
-		expect(adapter.getNoaaIndex(10.2, 52.7)).to.equal(1953);
+		expect(adapter.getNoaaIndex(52.7, 10.2)).to.equal(1953);
 	});
 
 	it("converts negative longitude before index calculation", () => {
 		const adapter = createAdapter({});
-		expect(adapter.getNoaaIndex(-10.4, 52.2)).to.equal(63492);
+		expect(adapter.getNoaaIndex(52.2, -10.4)).to.equal(63492);
 	});
 
 	it("rounds decimal inputs before indexing", () => {
 		const adapter = createAdapter({});
-		expect(adapter.getNoaaIndex(12.49, 48.5)).to.equal(adapter.getNoaaIndex(12, 49));
-		expect(adapter.getNoaaIndex(12.5, 48.49)).to.equal(adapter.getNoaaIndex(13, 48));
+		expect(adapter.getNoaaIndex(48.5, 12.49)).to.equal(adapter.getNoaaIndex(49, 12));
+		expect(adapter.getNoaaIndex(48.49, 12.5)).to.equal(adapter.getNoaaIndex(48, 13));
 	});
 
 	it("handles longitude boundary at -180 and 180 consistently", () => {
 		const adapter = createAdapter({});
-		expect(adapter.getNoaaIndex(-180, 0)).to.equal(adapter.getNoaaIndex(180, 0));
-		expect(adapter.getNoaaIndex(-180, -90)).to.equal(32580);
-		expect(adapter.getNoaaIndex(180, 90)).to.equal(32760);
+		expect(adapter.getNoaaIndex(0, -180)).to.equal(adapter.getNoaaIndex(0, 180));
+		expect(adapter.getNoaaIndex(-90, -180)).to.equal(32580);
+		expect(adapter.getNoaaIndex(90, 180)).to.equal(32760);
 	});
 
 	it("uses stored NOAA response and validates lon/lat/probability triplet at computed index", () => {
 		const adapter = createAdapter({});
-		const index = adapter.getNoaaIndex(0.2, -89.4);
+		const index = adapter.getNoaaIndex(-89.4, 0.2);
 		const triplet = noaaResponseExample.coordinates[index];
 
 		expect(index).to.equal(1);


### PR DESCRIPTION
### Motivation
- Make `getNoaaIndex` accept latitude first (latitude, longitude) so callers pass `lat` before `lon`, matching how geographic coordinates are documented and read.
- Align JSDoc and implementation so the function signature and documentation consistently reflect that latitude (Breite) comes first.
- Update all call sites and tests to prevent mismatches between parameter order and usage.

### Description
- Updated the JSDoc and function signature to `getNoaaIndex(latitude, longitude)` in `main.js` and adapted the internal rounding and index calculation accordingly.
- Changed the call in `onReady` to use `this.getNoaaIndex(lat, lon)` so the adapter passes latitude first when computing `ovationIndex`.
- Updated all unit test invocations in `main.test.js` to call `getNoaaIndex` with the new `(lat, lon)` order while preserving the expected index assertions.

### Testing
- Ran a smoke check by executing a small `node` snippet that imports the adapter with a mocked `@iobroker/adapter-core` and verified `getNoaaIndex(52.7, 10.2)` and `getNoaaIndex(52.2, -10.4)` produced the expected indices (success).
- Attempted to run `npm test -- --runInBand`, but the test run failed in this environment due to missing test runner (`mocha: not found`), so the full test suite could not be executed here (failure).
- Updated tests in `main.test.js` to the new parameter order so they will pass once the project's dev dependencies (including `mocha`) are installed and tests are run in a normal environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f66f1bed0832fb9ffcaebfe584bb9)