### PR TITLE
Improve NOAA payload robustness and add publish-readiness review

### DIFF
--- a/PUBLISH_REVIEW.md
+++ b/PUBLISH_REVIEW.md
@@ -1,0 +1,50 @@
+# Publish Readiness Review (ioBroker.aurora-borealis)
+
+## Executive summary
+
+Status: **Almost ready, but not fully publish-ready yet**.
+
+The adapter passes linting, unit tests, package validation, and TypeScript checks. Two robustness bugs were fixed during this review (timestamp parsing validation and handling of 0/0 system coordinates).
+
+There are still release-process gaps before publishing to npm/ioBroker stable:
+
+1. Changelog in `README.md` is still "WORK IN PROGRESS" and should be replaced by a real release entry.
+2. Integration test setup currently fails in this environment and should be executed in CI or a local ioBroker-capable setup before release confidence is considered complete.
+3. GitHub release workflow has npm deploy commented out, so release automation is not yet enabled.
+
+## What was validated
+
+- Adapter runtime logic in `main.js` (coordinate handling, NOAA fetch, payload parsing, state updates).
+- Unit tests in `main.test.js`.
+- ioBroker package metadata consistency (`package.json`, `io-package.json`).
+- Linting and type checks.
+
+## Improvements made in this review
+
+- Accept valid system coordinates even if latitude or longitude is `0`.
+- Added NOAA timestamp parsing validation with explicit errors for missing/malformed timestamps.
+- Added unit tests for timestamp parsing behavior.
+- Added defensive coordinate validation before NOAA index calculation.
+
+## Remaining publish blockers / recommendations
+
+### Must-do before first public release
+
+1. Replace `README.md` changelog placeholder with an actual `0.0.1` entry.
+2. Validate integration tests in CI/local environment where ioBroker test harness can initialize cleanly.
+3. Decide on release path:
+   - enable trusted publishing in workflow, or
+   - document manual release process clearly.
+
+### Nice-to-have
+
+- Add unit test coverage around `onReady()` behavior (state writes, coordinate source precedence).
+- Consider translating validator error texts in `admin/jsonConfig.json`.
+- Optionally reduce npm warning noise from environment-level `http-proxy` config in CI.
+
+## Commands used
+
+- `npm run lint`
+- `npm test`
+- `npm run check`
+- `npm run test:integration` (fails in this environment due missing generated ioBroker config file)

--- a/main.test.js
+++ b/main.test.js
@@ -86,6 +86,33 @@ describe("main.js helper methods", () => {
 		).to.throw("NOAA grid lookup failed");
 	});
 
+	it("parses NOAA observation and forecast times", () => {
+		const adapter = createAdapter({});
+		const payload = {
+			"Observation Time": "2026-02-25T09:12:00Z",
+			"Forecast Time": "2026-02-25T10:00:00Z",
+		};
+
+		// @ts-ignore
+		expect(adapter.parseNoaaTimestamp(payload, "Observation Time")).to.equal(1772010720000);
+		// @ts-ignore
+		expect(adapter.parseNoaaTimestamp(payload, "Forecast Time")).to.equal(1772013600000);
+	});
+
+	it("throws for missing or malformed NOAA timestamps", () => {
+		const adapter = createAdapter({});
+
+		expect(() =>
+			// @ts-ignore
+			adapter.parseNoaaTimestamp({}, "Observation Time"),
+		).to.throw("Invalid NOAA payload: missing Observation Time");
+
+		expect(() =>
+			// @ts-ignore
+			adapter.parseNoaaTimestamp({ "Observation Time": "invalid" }, "Observation Time"),
+		).to.throw("Invalid NOAA payload: malformed Observation Time");
+	});
+
 	it("fetches ovation JSON with user agent header", async () => {
 		// @ts-ignore
 		const adapter = createAdapter({ config: { ovationUrl: "https://example.invalid/noaa" } });


### PR DESCRIPTION
### Motivation
- Harden adapter behavior against malformed or missing NOAA payload fields and edge-case coordinates to avoid runtime failures during data fetch and state updates.
- Provide clear validation and error messages for timestamp parsing to make failures actionable.
- Capture a publish-readiness assessment to document remaining release tasks and test results.

### Description
- Added `parseNoaaTimestamp(data, field)` to validate and parse NOAA timestamp fields and throw explicit errors for missing or malformed values, and switched state writes to use it (`main.js`).
- Fixed system-coordinate handling so valid `0` values are accepted and converted to numbers, added a defensive `Number.isFinite` guard before NOAA index calculation, and initialized `lat`/`lon` to `NaN` to satisfy type checks (`main.js`).
- Added unit tests covering timestamp parsing success and failure cases (`main.test.js`).
- Added `PUBLISH_REVIEW.md` with a publish-readiness assessment and remaining recommendations (changelog, CI release automation, integration test environment notes).

### Testing
- Ran `npm run lint` and linting completed successfully.
- Ran unit and package tests with `npm test`, resulting in all unit checks passing (11 passing) and package validation passing (46 passing).
- Ran TypeScript checks with `npm run check` and resolved type issues so `tsc` succeeds after changes.
- Ran `npm run test:integration` which failed in this environment because the ioBroker integration harness could not initialize (missing `/tmp/.../iobroker-data/iobroker.json`), and this is documented in `PUBLISH_REVIEW.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f80fca288832fada34cc8f762cc4f)