### PR TITLE
Support Node.js 20: update package engines and CI matrix

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: ioBroker/testing-action-check@v1
         with:
-          node-version: '22.x'
+          node-version: '20.x'
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           # install-command: 'npm install'
           lint: true
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -75,7 +75,7 @@ jobs:
 #    steps:
 #      - uses: ioBroker/testing-action-deploy@v1
 #        with:
-#          node-version: '22.x'
+#          node-version: '20.x'
 #          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
 #          # install-command: 'npm install'
 #          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git+https://github.com/chrmenne/ioBroker.aurora-borealis.git"
   },
   "engines": {
-    "node": ">= 22"
+    "node": ">= 20"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.3.2"


### PR DESCRIPTION
### Motivation
- Lower the minimum Node.js requirement to `>= 20` to support running the adapter on Node 20 and to include Node 20 in CI validation.

### Description
- Change `package.json` engines from `"node": ">= 22"` to `"node": ">= 20"` to relax the minimum Node.js requirement.
- Update `.github/workflows/test-and-release.yml` to run lint checks with Node `20.x` and add `20.x` to the adapter-tests matrix (`[20.x, 22.x, 24.x]`), and adjust the commented deploy block node-version example to `20.x`.

### Testing
- No automated tests were executed as part of this PR; CI workflow changes will run `check-and-lint` and `adapter-tests` across Node `20.x`, `22.x`, and `24.x` on merge/PR according to the updated workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c3909028832f9ac71971b7178038)