### PR TITLE
Add tests for system/adapter coordinates and timer stubs in FakeAdapter

### DIFF
--- a/main.test.js
+++ b/main.test.js
@@ -10,6 +10,8 @@ class FakeAdapter extends EventEmitter {
 		super();
 		this.name = options.name;
 		this.config = options.config || {};
+		this.setTimeout = setTimeout;
+		this.clearTimeout = clearTimeout;
 		this.log = {
 			debug: () => {},
 			info: () => {},
@@ -166,5 +168,88 @@ describe("main.js helper methods", () => {
 		} finally {
 			global.fetch = originalFetch;
 		}
+	});
+
+	it("uses system coordinates and updates datapoints after successful NOAA request", async () => {
+		const adapter = createAdapter({
+			config: {
+				useSystemLocation: true,
+				ovationUrl: "https://example.invalid/noaa",
+			},
+		});
+		const stateCalls = [];
+		const objectCalls = [];
+		const terminateCalls = [];
+
+		adapter.setObjectNotExistsAsync = async (id, obj) => {
+			objectCalls.push({ id, obj });
+		};
+		adapter.getForeignObjectAsync = async (id) => {
+			expect(id).to.equal("system.config");
+			return { common: { latitude: -89.4, longitude: 0.2 } };
+		};
+		adapter.fetchOvation = async () => noaaResponseExample;
+		adapter.setState = async (id, state) => {
+			stateCalls.push({ id, state });
+		};
+		adapter.terminate = (code) => {
+			terminateCalls.push(code);
+		};
+
+		await adapter.onReady();
+
+		expect(objectCalls.map(call => call.id)).to.deep.equal([
+			"probability",
+			"observation_time",
+			"forecast_time",
+		]);
+		expect(stateCalls).to.deep.equal([
+			{ id: "probability", state: { val: 99, ack: true } },
+			{ id: "observation_time", state: { val: 1772010720000, ack: true } },
+			{ id: "forecast_time", state: { val: 1772013600000, ack: true } },
+		]);
+		expect(terminateCalls).to.deep.equal([0]);
+	});
+
+	it("uses adapter-configured coordinates and updates datapoints after successful NOAA request", async () => {
+		const adapter = createAdapter({
+			config: {
+				useSystemLocation: false,
+				latitude: -89.4,
+				longitude: 0.2,
+				ovationUrl: "https://example.invalid/noaa",
+			},
+		});
+		const stateCalls = [];
+		const objectCalls = [];
+		const terminateCalls = [];
+
+		adapter.setObjectNotExistsAsync = async (id, obj) => {
+			objectCalls.push({ id, obj });
+		};
+		adapter.getForeignObjectAsync = async () => {
+			throw new Error("system.config should not be read when adapter coordinates are configured");
+		};
+		adapter.fetchOvation = async () => noaaResponseExample;
+		adapter.setState = async (id, state) => {
+			stateCalls.push({ id, state });
+		};
+		adapter.terminate = (code) => {
+			terminateCalls.push(code);
+		};
+
+		await adapter.onReady();
+
+		expect(objectCalls.map(call => call.id)).to.deep.equal([
+			"probability",
+			"observation_time",
+			"forecast_time",
+		]);
+		expect(stateCalls).to.deep.equal([
+			{ id: "probability", state: { val: 99, ack: true } },
+			{ id: "observation_time", state: { val: 1772010720000, ack: true } },
+			{ id: "forecast_time", state: { val: 1772013600000, ack: true } },
+		]);
+		expect(terminateCalls).to.deep.equal([0]);
 	});
 });


### PR DESCRIPTION
### Motivation
- Ensure the adapter correctly reads location from either the system (`system.config`) or adapter `config` and then fetches and writes NOAA/ovation datapoints.  
- Provide `setTimeout`/`clearTimeout` on the test `FakeAdapter` so adapter code that relies on timers doesn't fail during tests.

### Description
- Added `setTimeout` and `clearTimeout` properties to the `FakeAdapter` class to mirror runtime adapter behavior.  
- Added a test `uses system coordinates and updates datapoints after successful NOAA request` that stubs `getForeignObjectAsync` to return `system.config` coordinates, stubs `fetchOvation` to return the example NOAA response, and asserts calls to `setObjectNotExistsAsync`, `setState`, and `terminate` with expected IDs and values.  
- Added a test `uses adapter-configured coordinates and updates datapoints after successful NOAA request` that configures adapter coordinates directly, ensures `system.config` is not read, stubs `fetchOvation`, and asserts the same object/state/terminate behavior.  
- Both tests validate created object IDs `probability`, `observation_time`, and `forecast_time` and expected state values (`probability: 99`, `observation_time: 1772010720000`, `forecast_time: 1772013600000`).

### Testing
- Ran the unit tests in `main.test.js` (via the repository test runner); the new tests executed against the mocked `FakeAdapter` and `fetchOvation` and completed successfully.  
- Existing tests in the same suite remain intact and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e203eb4ce0832f8a073accad9a3c47)